### PR TITLE
BIN 1135 | Add I2C protocol example

### DIFF
--- a/notebooks/I2C-Protocol-API/I2C-Protocol-Supernova-API.ipynb
+++ b/notebooks/I2C-Protocol-API/I2C-Protocol-Supernova-API.ipynb
@@ -237,7 +237,7 @@
       ">> New message from SUPERNOVA:\n",
       "{'id': 3, 'command': 96, 'name': 'GET USB STRING', 'length': 35, 'message': 'SN-A3AA8239E633655983941796F92EDE06'}\n",
       ">> New message from SUPERNOVA:\n",
-      "{'id': 4, 'command': 96, 'name': 'GET USB STRING', 'length': 19, 'message': 'FW-2.1.0-39-5ef8c27'}\n",
+      "{'id': 4, 'command': 96, 'name': 'GET USB STRING', 'length': 19, 'message': 'FW-2.1.0-41-626ce0d'}\n",
       ">> New message from SUPERNOVA:\n",
       "{'id': 5, 'command': 96, 'name': 'GET USB STRING', 'length': 4, 'message': 'HW-C'}\n"
      ]
@@ -304,46 +304,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``Supernova.i2cSetPullUpResistors(id, pullUpResistorsValue)``\n",
-    "\n",
-    "This method sets the I2C pull up resistors value for the SDA and SCL signals.\n",
-    "\n",
-    "  - ``id: int`` : A 2-byte integer that represents the transfer ID.\n",
-    "  - ``pullUpResistorsValue: I2cPullUpResistorsValue`` : This parameter indicates the desire pull up resistors value to be set in the SDA and SCL lines. This parameter can take the following values:\n",
-    "\n",
-    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_10kOhm``\n",
-    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_5kOhm``\n",
-    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_2_2kOhm``\n",
-    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_1kOhm``\n",
-    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_470Ohm``\n",
-    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_220Ohm``\n",
-    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_100Ohm``\n",
-    "\n",
-    "  Note: By default the pull up resistors are set to 10 kOhms"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ">> New message from SUPERNOVA:\n",
-      "{'id': 7, 'command': 40, 'name': 'I2C SET PULL UP RESISTORS', 'usb_error': 'CMD_SUCCESSFUL', 'manager_error': 'I2C_NO_ERROR', 'driver_error': 'POTENTIOMETER_NO_ERROR'}\n"
-     ]
-    }
-   ],
-   "source": [
-    "request_result = supernova.i2cSetPullUpResistors(getId(), I2cPullUpResistorsValue.I2C_PULLUP_5kOhm)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "``Supernova.i2cSetParameters(id, cancelTransfer=0x00, baudrate=0x00)``\n",
     "\n",
     "This method sets the I2C transfers baud rate and allows canceling the current transfer if necessary.\n",
@@ -359,6 +319,50 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 7, 'command': 33, 'name': 'I2C SET PARAMETERS', 'completed': 0, 'cancelTransfer': 0, 'baudrate': 32, 'divider': 9}\n"
+     ]
+    }
+   ],
+   "source": [
+    "request_result = supernova.i2cSetParameters(getId(), baudrate=1000000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.i2cSetPullUpResistors(id, pullUpResistorsValue)``\n",
+    "\n",
+    "This method sets the I2C pull up resistors value for the SDA and SCL signals.\n",
+    "\n",
+    "  - ``id: int`` : A 2-byte integer that represents the transfer ID.\n",
+    "  - ``pullUpResistorsValue: I2cPullUpResistorsValue`` : This parameter indicates the desire pull up resistors value to be set in the SDA and SCL lines. This parameter can take the following values:\n",
+    "\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_10kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_4_7kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_3_3kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_2_2kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_1_5kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_1kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_680Ohm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_470Ohm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_330Ohm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_220Ohm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_150Ohm``\n",
+    "\n",
+    "  Note: By default the pull up resistors are set to 10 kOhms"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
    "outputs": [
@@ -367,12 +371,12 @@
      "output_type": "stream",
      "text": [
       ">> New message from SUPERNOVA:\n",
-      "{'id': 8, 'command': 33, 'name': 'I2C SET PARAMETERS', 'completed': 0, 'cancelTransfer': 0, 'baudrate': 32, 'divider': 9}\n"
+      "{'id': 8, 'command': 40, 'name': 'I2C SET PULL UP RESISTORS', 'usb_error': 'CMD_SUCCESSFUL', 'manager_error': 'I2C_NO_ERROR', 'driver_error': 'POTENTIOMETER_SET_VALUE_NO_ERROR'}\n"
      ]
     }
    ],
    "source": [
-    "request_result = supernova.i2cSetParameters(getId(), baudrate=1000000)"
+    "request_result = supernova.i2cSetPullUpResistors(getId(), I2cPullUpResistorsValue.I2C_PULLUP_4_7kOhm)"
    ]
   },
   {
@@ -416,14 +420,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``Supernova.i2cWriteNonStop(id, slaveAddress, registerAddress: list, data: list)``\n",
+    "``Supernova.i2cReadFrom(id, slaveAddress, registerAddress: list, requestDataLength)``\n",
     "\n",
-    "This method is used to request the the USB device to perform an I2C write operation that starts with a START condition but the STOP condition is not performed after the last byte.\n",
+    "This method is used to request the USB device to perform an I2C read operation, preceded by an I2C write transfer to send the register/memory address from which the data will be read. A R-Start condition is performed between the I2C write and I2C read transfers.\n",
     "\n",
-    "  - ``id: int`` : A 2-byte integer that represents the transaction ID.\n",
+    "  - ``id: int`` : A 2-byte integer that represent the transaction ID.\n",
     "  - ``slaveAddress: c_uint8`` : I2C slave static address.\n",
-    "  - ``registerAddress: list `` : A Python list that contains the memory/register address of the I2C slave's internal memory, to which the data will be written.The list holds bytes, and it can have a length from 0 bytes up to 4 bytes. If the list is empty, the Supernova will ignore it and write only the data payload.\n",
-    "  - ``data: list`` : A Python list that contains the I2C data to be transferred in the I2C write operation. The list holds bytes elements, and the maximum length is 1024 bytes."
+    "  - ``registerAddress: list `` : A Python list that contains the memory/register address of the I2C slave's internal memory, from which the data will be read. The list holds bytes, and it can have a length from 0 bytes up to 4 bytes. If the list is empty, the Supernova will ignore it and only write the data payload.\n",
+    "  - ``requestDataLength: int`` : Length of the data to be read. The maximum value is 1024 bytes."
    ]
   },
   {
@@ -436,7 +440,43 @@
      "output_type": "stream",
      "text": [
       ">> New message from SUPERNOVA:\n",
-      "{'id': 10, 'command': 38, 'name': 'I2C WRITE WITHOUT STOP', 'status': 0, 'payloadLength': 128, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}\n"
+      "{'id': 10, 'command': 39, 'name': 'I2C READ FROM', 'status': 0, 'payloadLength': 70, 'data': [33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "SLAVE_ADDRESS =  0x50\n",
+    "SLAVE_REGISTER = [0,0]   # [reg, page]  \n",
+    "LENGTH = 70\n",
+    "\n",
+    "request_result = supernova.i2cReadFrom(getId(), SLAVE_ADDRESS, SLAVE_REGISTER, LENGTH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.i2cWriteNonStop(id, slaveAddress, registerAddress: list, data: list)``\n",
+    "\n",
+    "This method is used to request the the USB device to perform an I2C write operation that starts with a START condition but the STOP condition is not performed after the last byte.\n",
+    "\n",
+    "  - ``id: int`` : A 2-byte integer that represents the transaction ID.\n",
+    "  - ``slaveAddress: c_uint8`` : I2C slave static address.\n",
+    "  - ``registerAddress: list `` : A Python list that contains the memory/register address of the I2C slave's internal memory, to which the data will be written.The list holds bytes, and it can have a length from 0 bytes up to 4 bytes. If the list is empty, the Supernova will ignore it and write only the data payload.\n",
+    "  - ``data: list`` : A Python list that contains the I2C data to be transferred in the I2C write operation. The list holds bytes elements, and the maximum length is 1024 bytes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 11, 'command': 38, 'name': 'I2C WRITE WITHOUT STOP', 'status': 0, 'payloadLength': 128, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}\n"
      ]
     }
    ],
@@ -452,49 +492,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``Supernova.i2cRead(id, slaveAddress, requestDataLength)``\n",
-    "\n",
-    "This method is used to request the USB device to perform an I2C read operation that starts with a START condition, but the STOP condition is not performed after the last byte.\n",
-    "\n",
-    "\n",
-    "  - ``id: int`` : A 2-byte integer that represent the transaction ID.\n",
-    "  - ``slaveAddress: c_uint8`` : I2C slave static address.\n",
-    "  - ``requestDataLength: int`` : Length of data to be read. The maximum value is 1024 bytes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ">> New message from SUPERNOVA:\n",
-      "{'id': 11, 'command': 35, 'name': 'I2C READ', 'status': 0, 'payloadLength': 70, 'data': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}\n"
-     ]
-    }
-   ],
-   "source": [
-    "SLAVE_ADDRESS =  0x50  \n",
-    "LENGTH = 70\n",
-    "\n",
-    "request_result = supernova.i2cRead(getId(), SLAVE_ADDRESS,LENGTH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "``Supernova.i2cReadFrom(id, slaveAddress, registerAddress: list, requestDataLength)``\n",
     "\n",
-    "This method is used to request the USB device to perform an I2C read operation, preceded by an I2C write transfer to send the register/memory address from which the data will be read. An R-Start condition is performed between the I2C write and I2C read transfers.\n",
-    "\n",
-    "  - ``id: int`` : A 2-byte integer that represent the transaction ID.\n",
-    "  - ``slaveAddress: c_uint8`` : I2C slave static address.\n",
-    "  - ``registerAddress: list `` : A Python list that contains the memory/register address of the I2C slave's internal memory, from which the data will be read. The list holds bytes, and it can have a length from 0 bytes up to 4 bytes. If the list is empty, the Supernova will ignore it and only write the data payload.\n",
-    "  - ``requestDataLength: int`` : Length of the data to be read. The maximum value is 1024 bytes."
+    "To check the correct execution of the ``i2cWriteNonStop`` command, an ``i2cReadFrom`` command is performed, reading 70 bytes from the slave register [0, 0]"
    ]
   },
   {
@@ -523,9 +523,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Close communication\n",
+    "``Supernova.i2cRead(id, slaveAddress, requestDataLength)``\n",
     "\n",
-    "Use the ``Supernova.close()`` method to end the communication with the Supernova device and release the used memory in the background like threads and so on."
+    "This method is used to request the USB device to perform an I2C read operation that starts with a START condition, but the STOP condition is not performed after the last byte.\n",
+    "\n",
+    "\n",
+    "  - ``id: int`` : A 2-byte integer that represent the transaction ID.\n",
+    "  - ``slaveAddress: c_uint8`` : I2C slave static address.\n",
+    "  - ``requestDataLength: int`` : Length of data to be read. The maximum value is 1024 bytes."
    ]
   },
   {
@@ -534,12 +539,42 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 13, 'command': 35, 'name': 'I2C READ', 'status': 0, 'payloadLength': 70, 'data': [55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "SLAVE_ADDRESS =  0x50  \n",
+    "LENGTH = 70\n",
+    "\n",
+    "request_result = supernova.i2cRead(getId(), SLAVE_ADDRESS,LENGTH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Close communication\n",
+    "\n",
+    "Use the ``Supernova.close()`` method to end the communication with the Supernova device and release the used memory in the background like threads and so on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "text/plain": [
        "{'module': 0, 'opcode': 0, 'message': 'Communication closed successfully.'}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/I2C-Protocol-API/I2C-Protocol-Supernova-API.ipynb
+++ b/notebooks/I2C-Protocol-API/I2C-Protocol-Supernova-API.ipynb
@@ -1,0 +1,575 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import Python package\n",
+    "import BinhoSupernova\n",
+    "from BinhoSupernova.Supernova import Supernova\n",
+    "from BinhoSupernova.commands.definitions import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting started"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 1. List all the Supernova devices connected to the PC host\n",
+    "\n",
+    "The ``BinhoSupernova.getConnectedSupernovaDevicesList()`` gets a list of the Supernova devices plugged into the host PC machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'path': '\\\\\\\\?\\\\HID#VID_1FC9&PID_82FC#6&3a5fb9a5&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}',\n",
+       "  'vendor_id': '0x1fc9',\n",
+       "  'product_id': '0x82fc',\n",
+       "  'serial_number': 'A3AA8239E633655983941796F92EDE0',\n",
+       "  'release_number': 256,\n",
+       "  'manufacturer_string': 'Binho LLC',\n",
+       "  'product_string': 'Binho Supernova',\n",
+       "  'usage_page': 65280,\n",
+       "  'usage': 1,\n",
+       "  'interface_number': 0}]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "BinhoSupernova.getConnectedSupernovaDevicesList()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 2. Create an instance of the Supernova class\n",
+    "\n",
+    "To utilize a Supernova USB host adapter device, we need to create an instance of the Supernova class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a device instance. One instance of the Supernova class represents a Supernova USB host adapter device.\n",
+    "supernova = Supernova()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3. Open connection to the Supernova device\n",
+    "\n",
+    "The public method ``Supernova.open()`` establishes the connection with a Supernova device. Below is the complete signature:\n",
+    "\n",
+    "```python\n",
+    "open(vid, pid, serial, path, logEnable)\n",
+    "```\n",
+    "\n",
+    "- ``vid: int``: The Supernova USB VID, which is set by default.\n",
+    "- ``pid: int``: The Supernova USB PID, which is set by default.\n",
+    "- ``serial: str``: The Supernova serial number.\n",
+    "- ``path: str``: The OS HID path assigned to the device. This can be obtained using the ``BinhoSupernova.getConnectedSupernovaDevicesList()`` method. The ``path`` parameter is currently the only way to uniquely identify each Supernova device. Therefore, it is recommended to use the ``path`` parameter, especially when opening connections with more than one Supernova device simultaneously.\n",
+    "- ``logEnable``: A boolean flag to enable the logging of messages. Log messages are saved in a system directory based on the OS.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'module': 0,\n",
+       " 'opcode': 0,\n",
+       " 'message': 'Connection with Supernova device opened successfully.'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Use the method by default to connect to only one Supernova device.\n",
+    "supernova.open()\n",
+    "\n",
+    "# Otherwise, use the path attribute to identify each Supernova device. Uncomment the line below and comment the line #2.\n",
+    "# supernova.open(path='\\\\\\\\?\\\\HID#VID_1FC9&PID_82FC#6&48d9417&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4. Define and register a callback to handle responses and notifications from Supernova\n",
+    "\n",
+    "To handle responses and notifications from Supernova, a callback function must be defined and registered. This function will be invoked every time the Supernova sends a response to a request, an asynchronous notification, or a message from the system.\n",
+    "\n",
+    "The callback function's signature is as follows: \n",
+    "\n",
+    "``def callback_function_name(supernova_message: dict, system_message: dict) -> None:``\n",
+    "\n",
+    "Once the callback function is defined, it should be registered using the ``Supernova.onEvent(callback_function)`` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define callback function\n",
+    "def callback_function(supernova_message: dict, system_message: dict) -> None:\n",
+    "    \n",
+    "    if supernova_message != None:\n",
+    "\n",
+    "        # Print mesasage\n",
+    "        print(\">> New message from SUPERNOVA:\")\n",
+    "        print(supernova_message)\n",
+    "    \n",
+    "    if system_message != None:\n",
+    "\n",
+    "        # Print message\n",
+    "        print(\">> New message from the SYSTEM:\")\n",
+    "        print(system_message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'module': 0,\n",
+       " 'opcode': 0,\n",
+       " 'message': 'On event callback function registered successfully.'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Register callback function\n",
+    "supernova.onEvent(callback_function)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 5. Define a function to generate transaction IDs\n",
+    "\n",
+    "All the request messages sent to the Supernova from the USB Host application must include the transaction or request ID. The ID is a 2-byte integer with an allowed range of ``[0, 65535]``.\n",
+    "\n",
+    "In this example, a dummy function called ``getId()`` is defined to increment a transaction counter used as the ID."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Auxiliar code to generate IDs.\n",
+    "\n",
+    "counter_id = 0\n",
+    "\n",
+    "def getId():\n",
+    "    global counter_id\n",
+    "    counter_id = counter_id + 1\n",
+    "    return counter_id"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 6. Test communication with a basic command such as ``GET USB STRING``\n",
+    "\n",
+    "The ``GET USB STRING`` command allows you to retrieve various string values related to the product, such as the manufacturer, product name, serial number, firmware version, and hardware version. This command serves as a basic test to verify the communication and functionality with the Supernova device. By successfully receiving the expected string values, you can ensure that the communication between the PC host and the Supernova device is functioning as expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 1, 'command': 96, 'name': 'GET USB STRING', 'length': 12, 'message': 'MN-Binho LLC'}\n",
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 2, 'command': 96, 'name': 'GET USB STRING', 'length': 18, 'message': 'PR-Binho Supernova'}\n",
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 3, 'command': 96, 'name': 'GET USB STRING', 'length': 35, 'message': 'SN-A3AA8239E633655983941796F92EDE06'}\n",
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 4, 'command': 96, 'name': 'GET USB STRING', 'length': 19, 'message': 'FW-2.1.0-39-5ef8c27'}\n",
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 5, 'command': 96, 'name': 'GET USB STRING', 'length': 4, 'message': 'HW-C'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET USB STRING - Get Manufacturer\n",
+    "request_result = supernova.getUsbString(getId(), GetUsbStringSubCommand.MANUFACTURER)\n",
+    "\n",
+    "# GET USB STRING  - Get Product Name\n",
+    "request_result = supernova.getUsbString(getId(), GetUsbStringSubCommand.PRODUCT_NAME)\n",
+    "\n",
+    "# GET USB STRING  - Get Serial Number\n",
+    "request_result = supernova.getUsbString(getId(), GetUsbStringSubCommand.SERIAL_NUMBER)\n",
+    "\n",
+    "# GET USB STRING  - Firmware Version\n",
+    "request_result = supernova.getUsbString(getId(), GetUsbStringSubCommand.FW_VERSION)\n",
+    "\n",
+    "# GET USB STRING  - Hardware Version\n",
+    "request_result = supernova.getUsbString(getId(), GetUsbStringSubCommand.HW_VERSION)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## I2C Protocol API\n",
+    "\n",
+    "The I2C Protocol API methods are described below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.setI2cSpiUartBusVoltage(id, bus_voltage_in_mV)``\n",
+    "\n",
+    "This method supplies the indicated voltage to the bus in mV, ranging from 1200 mV up to 3300 mV. \n",
+    "\n",
+    "- ``id: int`` : A 2-byte integer that represents the transfer ID.\n",
+    "- ``bus_voltage_in_mV: c_int16 ``: The voltage parameter is a 2-byte integer in the range [1200, 3300]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 6, 'command': 100, 'name': 'SET I2C-SPI-UART BUS VOLTAGE', 'result': 0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "request_result = supernova.setI2cSpiUartBusVoltage(getId(), 3300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.i2cSetPullUpResistors(id, pullUpResistorsValue)``\n",
+    "\n",
+    "This method sets the I2C pull up resistors value for the SDA and SCL signals.\n",
+    "\n",
+    "  - ``id: int`` : A 2-byte integer that represents the transfer ID.\n",
+    "  - ``pullUpResistorsValue: I2cPullUpResistorsValue`` : This parameter indicates the desire pull up resistors value to be set in the SDA and SCL lines. This parameter can take the following values:\n",
+    "\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_10kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_5kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_2_2kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_1kOhm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_470Ohm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_220Ohm``\n",
+    "    - ``I2cPullUpResistorsValue.I2C_PULLUP_100Ohm``\n",
+    "\n",
+    "  Note: By default the pull up resistors are set to 10 kOhms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 7, 'command': 40, 'name': 'I2C SET PULL UP RESISTORS', 'usb_error': 'CMD_SUCCESSFUL', 'manager_error': 'I2C_NO_ERROR', 'driver_error': 'POTENTIOMETER_NO_ERROR'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "request_result = supernova.i2cSetPullUpResistors(getId(), I2cPullUpResistorsValue.I2C_PULLUP_5kOhm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.i2cSetParameters(id, cancelTransfer=0x00, baudrate=0x00)``\n",
+    "\n",
+    "This method sets the I2C transfers baud rate and allows canceling the current transfer if necessary.\n",
+    "\n",
+    "  - ``id: int`` : A 2-byte integer that represents the transfer ID.\n",
+    "  - ``cancelTransfer: int`` : A subcommand that allows canceling the last I2C transfer if it is still running. This parameter can take two possible values:\n",
+    "\n",
+    "    - ``0x00:`` Don't cancel current transfer.\n",
+    "    - ``0x01:`` Cancel current transfer.\n",
+    "\n",
+    "- ``baudrate : int`` : This parameter represents the I2C SCL frequency in Hz. Currently, the maximum allowed value is 1000000, which corresponds to 1 MHz."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 8, 'command': 33, 'name': 'I2C SET PARAMETERS', 'completed': 0, 'cancelTransfer': 0, 'baudrate': 32, 'divider': 9}\n"
+     ]
+    }
+   ],
+   "source": [
+    "request_result = supernova.i2cSetParameters(getId(), baudrate=1000000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.i2cWrite(id, slaveAddress, registerAddress: list, data: list)``\n",
+    "\n",
+    "This method is used to request to the the Supernova device to perform an I2C write transfer. The\n",
+    "I2C write transfer starts with a START condition and ends with a STOP condition.\n",
+    "\n",
+    "  - ``id: int`` : It is a 2-bytes integer that represent the transfer id.\n",
+    "  - ``slavAddress: c_uint8`` : I2C slave static address.\n",
+    "  - ``registerAddress: list `` : A Python list that contains the memory/register address of the I2C slave's internal memory, to which the data will be written. The list holds bytes, and can have a length from 0 bytes up to 4 bytes. If the list is empty, the Supernova will ignore it and write only the data payload.\n",
+    "  - ``data: list`` : A Python list that contains the I2C data to be transferred in the I2C write operation. The list holds bytes elements, and the maximum length is 1024 bytes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 9, 'command': 34, 'name': 'I2C WRITE', 'status': 0, 'payloadLength': 128, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "SLAVE_ADDRESS   = 0x50\n",
+    "SLAVE_REGISTER = [0,0]   # [reg, page]  \n",
+    "data = [33 for i in range(1,129)]\n",
+    "\n",
+    "request_result = supernova.i2cWrite(getId(), SLAVE_ADDRESS, SLAVE_REGISTER, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.i2cWriteNonStop(id, slaveAddress, registerAddress: list, data: list)``\n",
+    "\n",
+    "This method is used to request the the USB device to perform an I2C write operation that starts with a START condition but the STOP condition is not performed after the last byte.\n",
+    "\n",
+    "  - ``id: int`` : A 2-byte integer that represents the transaction ID.\n",
+    "  - ``slaveAddress: c_uint8`` : I2C slave static address.\n",
+    "  - ``registerAddress: list `` : A Python list that contains the memory/register address of the I2C slave's internal memory, to which the data will be written.The list holds bytes, and it can have a length from 0 bytes up to 4 bytes. If the list is empty, the Supernova will ignore it and write only the data payload.\n",
+    "  - ``data: list`` : A Python list that contains the I2C data to be transferred in the I2C write operation. The list holds bytes elements, and the maximum length is 1024 bytes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 10, 'command': 38, 'name': 'I2C WRITE WITHOUT STOP', 'status': 0, 'payloadLength': 128, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "SLAVE_ADDRESS   = 0x50\n",
+    "SLAVE_REGISTER = [0,0]   # [reg, page]  \n",
+    "data = [55 for i in range(1,129)]\n",
+    "\n",
+    "request_result = supernova.i2cWriteNonStop(getId(), SLAVE_ADDRESS, SLAVE_REGISTER, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.i2cRead(id, slaveAddress, requestDataLength)``\n",
+    "\n",
+    "This method is used to request the USB device to perform an I2C read operation that starts with a START condition, but the STOP condition is not performed after the last byte.\n",
+    "\n",
+    "\n",
+    "  - ``id: int`` : A 2-byte integer that represent the transaction ID.\n",
+    "  - ``slaveAddress: c_uint8`` : I2C slave static address.\n",
+    "  - ``requestDataLength: int`` : Length of data to be read. The maximum value is 1024 bytes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 11, 'command': 35, 'name': 'I2C READ', 'status': 0, 'payloadLength': 70, 'data': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "SLAVE_ADDRESS =  0x50  \n",
+    "LENGTH = 70\n",
+    "\n",
+    "request_result = supernova.i2cRead(getId(), SLAVE_ADDRESS,LENGTH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Supernova.i2cReadFrom(id, slaveAddress, registerAddress: list, requestDataLength)``\n",
+    "\n",
+    "This method is used to request the USB device to perform an I2C read operation, preceded by an I2C write transfer to send the register/memory address from which the data will be read. An R-Start condition is performed between the I2C write and I2C read transfers.\n",
+    "\n",
+    "  - ``id: int`` : A 2-byte integer that represent the transaction ID.\n",
+    "  - ``slaveAddress: c_uint8`` : I2C slave static address.\n",
+    "  - ``registerAddress: list `` : A Python list that contains the memory/register address of the I2C slave's internal memory, from which the data will be read. The list holds bytes, and it can have a length from 0 bytes up to 4 bytes. If the list is empty, the Supernova will ignore it and only write the data payload.\n",
+    "  - ``requestDataLength: int`` : Length of the data to be read. The maximum value is 1024 bytes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">> New message from SUPERNOVA:\n",
+      "{'id': 12, 'command': 39, 'name': 'I2C READ FROM', 'status': 0, 'payloadLength': 70, 'data': [55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "SLAVE_ADDRESS =  0x50\n",
+    "SLAVE_REGISTER = [0,0]   # [reg, page]  \n",
+    "LENGTH = 70\n",
+    "\n",
+    "request_result = supernova.i2cReadFrom(getId(), SLAVE_ADDRESS, SLAVE_REGISTER, LENGTH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Close communication\n",
+    "\n",
+    "Use the ``Supernova.close()`` method to end the communication with the Supernova device and release the used memory in the background like threads and so on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'module': 0, 'opcode': 0, 'message': 'Communication closed successfully.'}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Close the communication with the Supernova device.\n",
+    "supernova.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/I2C-Protocol-API/README.md
+++ b/notebooks/I2C-Protocol-API/README.md
@@ -1,0 +1,23 @@
+# Demo of Supernova I2C API
+
+This folder contains a demonstration project to test the Supernova host adapter I2C Protocol API. The different commands are tested showing the capabilities of the feature. For a more illustrative experience, this commands are tested using a FRAM memory [MB85RC56V](https://cdn-learn.adafruit.com/assets/assets/000/043/904/original/MB85RC256V-DS501-00017-3v0-E.pdf?1500009796) connected to the I2C Qwiic connector of the Supernova.
+
+## Prerequisites
+
+- Python 3.10
+- Supernova host adapter with Qwiic connector
+- Adafruit I2C Non-Volatile FRAM Breakout - 256Kbit / 32KByte
+
+## Installation
+
+1. **Install Dependencies:**
+
+   Use the provided `requirements.txt` to install the necessary Python packages.
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+Follow the instructions on the I2C-Protocol-Supernova-API notebook.

--- a/notebooks/I2C-Protocol-API/requirements.txt
+++ b/notebooks/I2C-Protocol-API/requirements.txt
@@ -1,0 +1,1 @@
+BinhoSupernova == 2.2.0

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -3,3 +3,4 @@ This folder contains various Jupyter Notebooks with hands-on demonstrations and 
 - **PIC18QF16Q20-I3C-to-SPI-I2C-translator:** Tutorial on the PIC18QF16Q20 protocol translator feature with Supernova API.
 - **SPI-Protocol-API:** Tutorial on how to use Supernova API to perform SPI protocol transactions.
 - **UART-Protocol-API:** Tutorial on how to use Supernova API to perform UART protocol transactions.
+- **I2C-Protocol-API:** Tutorial on how to use Supernova API to perform I2C protocol transactions.


### PR DESCRIPTION
This PR adds the I2C protocol example notebook to the correspondent folder, along with documentation explaining the requirements and procedure necessary to run the example. It also updates the README of the notebooks folder to add the description of the I2C-Protocol-API folder.