### PR TITLE
Fix import path and update I2C bus initialization error handling

### DIFF
--- a/PulsarSDK-Examples/blocking-api/I2C-ICM42605/pulsar_blocking_api.py
+++ b/PulsarSDK-Examples/blocking-api/I2C-ICM42605/pulsar_blocking_api.py
@@ -16,7 +16,7 @@ class PulsarBlockingApi:
 
         self.pulsar = Pulsar()
         self.pulsar.onEvent(self.__on_receive_callback)
-        self.i2c_definitions = __import__("BinhoPulsar.commands.i2c.definitions", fromlist=[""])
+        self.i2c_definitions = __import__("binhopulsar.commands.i2c.definitions", fromlist=[""])
 
         self.response_event = threading.Event()
         self.response = dict()

--- a/PulsarSDK-Examples/blocking-api/I2C-ICM42605/run_demo.py
+++ b/PulsarSDK-Examples/blocking-api/I2C-ICM42605/run_demo.py
@@ -26,7 +26,7 @@ def main():
                                           frequency=frequency,
                                           pullUpResistorsValue=pullUpResistorsValue)
 
-    if not response['result'] in [pulsar.i2c_definitions.CommonResultCodes.SUCCESS.name, pulsar.i2c_definitions.CommonResultCodes.BUS_ALREADY_INITIALIZED.name]:
+    if not response['result'] in [pulsar.i2c_definitions.CommonResultCodes.SUCCESS.name, pulsar.i2c_definitions.CommonResultCodes.INTERFACE_ALREADY_INITIALIZED.name]:
         print("Error initializing the I2C bus")
         exit(1)
 


### PR DESCRIPTION
# Changes
This PR modifies the import path of the Pulsar SDK definitions due to the rename of the Python package. It also updates the expected error for the bus re-initialization from `BUS_ALREADY_INITILIAZED` to `INTERFACE_ALREADY_INITIALIZED`.