### PR TITLE
BIN-1573: Fix bug in I3C CONTROLLER CCC TRANSFER

### DIFF
--- a/SupernovaSDK-Examples/notebooks/I3C-Protocol-API/I3C-Protocol-Controller-API/I3C-Protocol-Controller-API-Basic/I3C-Protocol-DAA.ipynb
+++ b/SupernovaSDK-Examples/notebooks/I3C-Protocol-API/I3C-Protocol-Controller-API/I3C-Protocol-Controller-API-Basic/I3C-Protocol-DAA.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,23 +84,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{'path': '\\\\\\\\?\\\\HID#VID_1FC9&PID_82FC#7&9e2d326&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}',\n",
+       "[{'path': '\\\\\\\\?\\\\HID#VID_1FC9&PID_82FC#7&84d1a57&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}',\n",
        "  'vendor_id': '0x1fc9',\n",
        "  'product_id': '0x82fc',\n",
-       "  'serial_number': '5F4BCE79166A34559DF3081DF5A8769D',\n",
+       "  'serial_number': '0A071E8504C72D59A5FFE0350EDD2A9E',\n",
        "  'manufacturer_string': 'Binho LLC',\n",
        "  'product_string': 'Binho Supernova',\n",
        "  'hardware_version': 'C',\n",
-       "  'firmware_version': '4.1.2'}]"
+       "  'firmware_version': '4.2.0'}]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -158,7 +158,7 @@
        " 'message': 'Connection with Supernova device opened successfully.'}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +222,7 @@
        " 'message': 'On event callback function registered successfully.'}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -269,7 +269,7 @@
        "{'module': 1, 'opcode': 0, 'message': 'I3C CONTROLLER INIT request success'}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -508,9 +508,9 @@
     "'''\n",
     "table = {0: {'staticAddress': BMM350_STATIC_ADDRESS,\n",
     "        'dynamicAddress': BMM350_DYNAMIC_ADDRESS,\n",
-    "        'bcr': 0x00,\n",
-    "        'dcr': 0x00,\n",
-    "        'pid': [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],\n",
+    "        'bcr': 0x26,\n",
+    "        'dcr': 0x43,\n",
+    "        'pid': [0x07, 0x70, 0x10, 0x33, 0x00, 0x00],\n",
     "        'configuration': BMM350_CONFIGURATION}}\n",
     "\n",
     "'''\n",
@@ -529,7 +529,7 @@
      "output_type": "stream",
      "text": [
       ">> New message from SUPERNOVA:\n",
-      "{'id': 9, 'command': 'I3C CONTROLLER GET TARGET DEVICES TABLE', 'result': 'SUCCESS', 'number_of_targets': 2, 'table': [{'static_address': 20, 'dynamic_address': 12, 'pid': [0, 0, 0, 0, 0, 0], 'bcr': 0, 'dcr': 0, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'DO_NOT_USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}, {'static_address': 0, 'dynamic_address': 8, 'pid': [2, 8, 0, 112, 146, 11], 'bcr': 7, 'dcr': 68, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}]}\n"
+      "{'id': 9, 'command': 'I3C CONTROLLER GET TARGET DEVICES TABLE', 'result': 'SUCCESS', 'number_of_targets': 2, 'table': [{'static_address': 20, 'dynamic_address': 12, 'pid': [7, 112, 16, 51, 0, 0], 'bcr': 38, 'dcr': 67, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'DO_NOT_USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}, {'static_address': 0, 'dynamic_address': 8, 'pid': [2, 8, 0, 112, 146, 11], 'bcr': 7, 'dcr': 68, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}]}\n"
      ]
     }
    ],
@@ -854,9 +854,9 @@
     "\"\"\"\n",
     "table = {0: {'staticAddress': BMM350_STATIC_ADDRESS,\n",
     "        'dynamicAddress': BMM350_DYNAMIC_ADDRESS,\n",
-    "        'bcr': 0x00,\n",
-    "        'dcr': 0x00,\n",
-    "        'pid': [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],\n",
+    "        'bcr': 0x26,\n",
+    "        'dcr': 0x43,\n",
+    "        'pid': [0x07, 0x70, 0x10, 0x33, 0x00, 0x00],\n",
     "        'configuration': BMM350_CONFIGURATION}}\n",
     "\n",
     "# Initialize and scan the I3C bus.\n",
@@ -873,7 +873,7 @@
      "output_type": "stream",
      "text": [
       ">> New message from SUPERNOVA:\n",
-      "{'id': 21, 'command': 'I3C CONTROLLER GET TARGET DEVICES TABLE', 'result': 'SUCCESS', 'number_of_targets': 2, 'table': [{'static_address': 0, 'dynamic_address': 8, 'pid': [2, 8, 0, 112, 146, 11], 'bcr': 7, 'dcr': 68, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}, {'static_address': 0, 'dynamic_address': 9, 'pid': [7, 112, 16, 51, 0, 0], 'bcr': 38, 'dcr': 67, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}]}\n"
+      "{'id': 21, 'command': 'I3C CONTROLLER GET TARGET DEVICES TABLE', 'result': 'SUCCESS', 'number_of_targets': 2, 'table': [{'static_address': 0, 'dynamic_address': 8, 'pid': [2, 8, 0, 112, 146, 11], 'bcr': 7, 'dcr': 68, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}, {'static_address': 20, 'dynamic_address': 12, 'pid': [7, 112, 16, 51, 0, 0], 'bcr': 38, 'dcr': 67, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}]}\n"
      ]
     }
    ],
@@ -920,7 +920,7 @@
      "output_type": "stream",
      "text": [
       ">> New message from SUPERNOVA:\n",
-      "{'id': 23, 'command': 'I3C CONTROLLER GET TARGET DEVICES TABLE', 'result': 'SUCCESS', 'number_of_targets': 2, 'table': [{'static_address': 0, 'dynamic_address': 15, 'pid': [2, 8, 0, 112, 146, 11], 'bcr': 7, 'dcr': 68, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}, {'static_address': 0, 'dynamic_address': 9, 'pid': [7, 112, 16, 51, 0, 0], 'bcr': 38, 'dcr': 67, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}]}\n"
+      "{'id': 23, 'command': 'I3C CONTROLLER GET TARGET DEVICES TABLE', 'result': 'SUCCESS', 'number_of_targets': 2, 'table': [{'static_address': 0, 'dynamic_address': 15, 'pid': [2, 8, 0, 112, 146, 11], 'bcr': 7, 'dcr': 68, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}, {'static_address': 20, 'dynamic_address': 12, 'pid': [7, 112, 16, 51, 0, 0], 'bcr': 38, 'dcr': 67, 'mwl': 0, 'mrl': 0, 'max_ibi_payload_length': 0, 'configuration': {'target_type': 'I3C_DEVICE', 'interrupt_request': 'ACCEPT_IBI', 'controller_role_request': 'REJECT_CRR', 'setdasa': 'DO_NOT_USE_SETDASA', 'setaasa': 'DO_NOT_USE_SETAASA', 'entdaa': 'USE_ENTDAA', 'ibi_timestamp': 'DISABLE_IBIT', 'pending_read_capability': 'DISABLE_AUTOMATIC_READ'}}]}\n"
      ]
     }
    ],
@@ -970,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -979,7 +979,7 @@
        "{'module': 0, 'opcode': 0, 'message': 'Communication closed successfully.'}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/SupernovaSDK-Examples/notebooks/I3C-Protocol-API/I3C-Protocol-Controller-API/I3C-Protocol-Controller-API-Basic/I3C-Protocol-DAA.ipynb
+++ b/SupernovaSDK-Examples/notebooks/I3C-Protocol-API/I3C-Protocol-Controller-API/I3C-Protocol-Controller-API-Basic/I3C-Protocol-DAA.ipynb
@@ -802,7 +802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -822,7 +822,7 @@
     "BMM350_STATIC_ADDRESS = 0x14\n",
     "\n",
     "\"\"\"\n",
-    "Select the dynamic address to be assigned to the I3C Target if the DAA method is a SETDASA.\n",
+    "Select the dynamic address to be assigned to the I3C Target if the DAA method is a SETDASA or ENTDAA.\n",
     "\"\"\"\n",
     "BMM350_DYNAMIC_ADDRESS = 0x0C\n",
     "\n",


### PR DESCRIPTION
## Resolves
[BIN-1573](https://focusuy.atlassian.net/browse/BIN-1573)

## Changes
This PR updates the I3C DAA notebook. It adds the values for PID, BCR, and DCR to the cells that use a Target Device Table and updates the obtained results.

## How to test
1. Build the firmware version of `fnavadian-bin-1573` branch and install the associated branch in the SupernovaSDK repo
2. Use the I3C DAA notebook, checkouted in this branch
3. Corroborate the result of the i3cENTDAA method with the configuration sent. Use the attached files of the ticket to corroborate the resultant table as well